### PR TITLE
Added cuda checks to enable inference via the universal demo

### DIFF
--- a/mseg_semantic/tool/universal_demo.py
+++ b/mseg_semantic/tool/universal_demo.py
@@ -71,7 +71,8 @@ def run_universal_demo(args, use_gpu: bool = True) -> None:
         input_file=args.input_file,
         model_taxonomy='universal',
         eval_taxonomy='universal',
-        scales = args.scales
+        scales = args.scales,
+        use_gpu=use_gpu
     )
     itask.execute()
 


### PR DESCRIPTION
Hi all,
I added some conditionals around the cuda calls to enable some inference via cpu. 
The changes made allowed me to successfully run:
```
python -u mseg_semantic/tool/universal_demo.py   --config=mseg_semantic/config/test/default_config_360_ss.yaml   model_name mseg-3m   model_path ./mseg-3m-480p.pth input_file $IMAGE
```