### PR TITLE
Remove apex inference dependencies and remove yacs, for Hydra

### DIFF
--- a/mseg_semantic/model/seg_hrnet.py
+++ b/mseg_semantic/model/seg_hrnet.py
@@ -7,16 +7,16 @@ from __future__ import print_function
 import os
 import logging
 import functools
+from pathlib import Path
 
 import numpy as np
-
 import torch
 import torch.nn as nn
 import torch._utils
 import torch.nn.functional as F
-import apex
+
 import pdb
-from pathlib import Path
+
 
 """
 "High-Resolution Representations for Labeling Pixels and Regions"
@@ -25,16 +25,16 @@ https://arxiv.org/pdf/1904.04514.pdf
 Code adopted from https://github.com/HRNet/HRNet-Semantic-Segmentation
 """
 
-BatchNorm2d = apex.parallel.SyncBatchNorm
+BatchNorm2d = torch.nn.SyncBatchNorm
 BN_MOMENTUM = 0.01
 logger = logging.getLogger(__name__)
 
 _ROOT = Path(__file__).resolve().parent
 
+
 def conv3x3(in_planes, out_planes, stride=1):
     """3x3 convolution with padding"""
-    return nn.Conv2d(in_planes, out_planes, kernel_size=3, stride=stride,
-                     padding=1, bias=False)
+    return nn.Conv2d(in_planes, out_planes, kernel_size=3, stride=stride, padding=1, bias=False)
 
 
 class BasicBlock(nn.Module):
@@ -42,6 +42,7 @@ class BasicBlock(nn.Module):
     Identical to ResNet BasicBlock, but we hardcode the
     Batchnorm variant and momentum.
     """
+
     expansion = 1
 
     def __init__(self, inplanes, planes, stride=1, downsample=None):
@@ -78,19 +79,17 @@ class Bottleneck(nn.Module):
     Identical to ResNet Bottleneck, but we hardcode the
     Batchnorm variant and momentum.
     """
+
     expansion = 4
 
     def __init__(self, inplanes, planes, stride=1, downsample=None):
         super(Bottleneck, self).__init__()
         self.conv1 = nn.Conv2d(inplanes, planes, kernel_size=1, bias=False)
         self.bn1 = BatchNorm2d(planes, momentum=BN_MOMENTUM)
-        self.conv2 = nn.Conv2d(planes, planes, kernel_size=3, stride=stride,
-                               padding=1, bias=False)
+        self.conv2 = nn.Conv2d(planes, planes, kernel_size=3, stride=stride, padding=1, bias=False)
         self.bn2 = BatchNorm2d(planes, momentum=BN_MOMENTUM)
-        self.conv3 = nn.Conv2d(planes, planes * self.expansion, kernel_size=1,
-                               bias=False)
-        self.bn3 = BatchNorm2d(planes * self.expansion,
-                               momentum=BN_MOMENTUM)
+        self.conv3 = nn.Conv2d(planes, planes * self.expansion, kernel_size=1, bias=False)
+        self.bn3 = BatchNorm2d(planes * self.expansion, momentum=BN_MOMENTUM)
         self.relu = nn.ReLU(inplace=True)
         self.downsample = downsample
         self.stride = stride
@@ -119,11 +118,11 @@ class Bottleneck(nn.Module):
 
 
 class HighResolutionModule(nn.Module):
-    def __init__(self, num_branches, blocks, num_blocks, num_inchannels,
-                 num_channels, fuse_method, multi_scale_output=True):
+    def __init__(
+        self, num_branches, blocks, num_blocks, num_inchannels, num_channels, fuse_method, multi_scale_output=True
+    ) -> None:
         super(HighResolutionModule, self).__init__()
-        self._check_branches(
-            num_branches, blocks, num_blocks, num_inchannels, num_channels)
+        self._check_branches(num_branches, blocks, num_blocks, num_inchannels, num_channels)
 
         self.num_inchannels = num_inchannels
         self.fuse_method = fuse_method
@@ -131,52 +130,45 @@ class HighResolutionModule(nn.Module):
 
         self.multi_scale_output = multi_scale_output
 
-        self.branches = self._make_branches(
-            num_branches, blocks, num_blocks, num_channels)
+        self.branches = self._make_branches(num_branches, blocks, num_blocks, num_channels)
         self.fuse_layers = self._make_fuse_layers()
         self.relu = nn.ReLU(inplace=True)
 
-    def _check_branches(self, num_branches, blocks, num_blocks,
-                        num_inchannels, num_channels):
+    def _check_branches(self, num_branches, blocks, num_blocks, num_inchannels, num_channels):
         if num_branches != len(num_blocks):
-            error_msg = 'NUM_BRANCHES({}) <> NUM_BLOCKS({})'.format(
-                num_branches, len(num_blocks))
+            error_msg = "NUM_BRANCHES({}) <> NUM_BLOCKS({})".format(num_branches, len(num_blocks))
             logger.error(error_msg)
             raise ValueError(error_msg)
 
         if num_branches != len(num_channels):
-            error_msg = 'NUM_BRANCHES({}) <> NUM_CHANNELS({})'.format(
-                num_branches, len(num_channels))
+            error_msg = "NUM_BRANCHES({}) <> NUM_CHANNELS({})".format(num_branches, len(num_channels))
             logger.error(error_msg)
             raise ValueError(error_msg)
 
         if num_branches != len(num_inchannels):
-            error_msg = 'NUM_BRANCHES({}) <> NUM_INCHANNELS({})'.format(
-                num_branches, len(num_inchannels))
+            error_msg = "NUM_BRANCHES({}) <> NUM_INCHANNELS({})".format(num_branches, len(num_inchannels))
             logger.error(error_msg)
             raise ValueError(error_msg)
 
-    def _make_one_branch(self, branch_index, block, num_blocks, num_channels,
-                         stride=1):
+    def _make_one_branch(self, branch_index, block, num_blocks, num_channels, stride=1):
         downsample = None
-        if stride != 1 or \
-           self.num_inchannels[branch_index] != num_channels[branch_index] * block.expansion:
+        if stride != 1 or self.num_inchannels[branch_index] != num_channels[branch_index] * block.expansion:
             downsample = nn.Sequential(
-                nn.Conv2d(self.num_inchannels[branch_index],
-                          num_channels[branch_index] * block.expansion,
-                          kernel_size=1, stride=stride, bias=False),
-                BatchNorm2d(num_channels[branch_index] * block.expansion,
-                            momentum=BN_MOMENTUM),
+                nn.Conv2d(
+                    self.num_inchannels[branch_index],
+                    num_channels[branch_index] * block.expansion,
+                    kernel_size=1,
+                    stride=stride,
+                    bias=False,
+                ),
+                BatchNorm2d(num_channels[branch_index] * block.expansion, momentum=BN_MOMENTUM),
             )
 
         layers = []
-        layers.append(block(self.num_inchannels[branch_index],
-                            num_channels[branch_index], stride, downsample))
-        self.num_inchannels[branch_index] = \
-            num_channels[branch_index] * block.expansion
+        layers.append(block(self.num_inchannels[branch_index], num_channels[branch_index], stride, downsample))
+        self.num_inchannels[branch_index] = num_channels[branch_index] * block.expansion
         for i in range(1, num_blocks[branch_index]):
-            layers.append(block(self.num_inchannels[branch_index],
-                                num_channels[branch_index]))
+            layers.append(block(self.num_inchannels[branch_index], num_channels[branch_index]))
 
         return nn.Sequential(*layers)
 
@@ -184,8 +176,7 @@ class HighResolutionModule(nn.Module):
         branches = []
 
         for i in range(num_branches):
-            branches.append(
-                self._make_one_branch(i, block, num_blocks, num_channels))
+            branches.append(self._make_one_branch(i, block, num_blocks, num_channels))
 
         return nn.ModuleList(branches)
 
@@ -200,36 +191,34 @@ class HighResolutionModule(nn.Module):
             fuse_layer = []
             for j in range(num_branches):
                 if j > i:
-                    fuse_layer.append(nn.Sequential(
-                        nn.Conv2d(num_inchannels[j],
-                                  num_inchannels[i],
-                                  1,
-                                  1,
-                                  0,
-                                  bias=False),
-                        BatchNorm2d(num_inchannels[i], momentum=BN_MOMENTUM)))
+                    fuse_layer.append(
+                        nn.Sequential(
+                            nn.Conv2d(num_inchannels[j], num_inchannels[i], 1, 1, 0, bias=False),
+                            BatchNorm2d(num_inchannels[i], momentum=BN_MOMENTUM),
+                        )
+                    )
                 elif j == i:
                     fuse_layer.append(None)
                 else:
                     conv3x3s = []
-                    for k in range(i-j):
+                    for k in range(i - j):
                         if k == i - j - 1:
                             num_outchannels_conv3x3 = num_inchannels[i]
-                            conv3x3s.append(nn.Sequential(
-                                nn.Conv2d(num_inchannels[j],
-                                          num_outchannels_conv3x3,
-                                          3, 2, 1, bias=False),
-                                BatchNorm2d(num_outchannels_conv3x3, 
-                                            momentum=BN_MOMENTUM)))
+                            conv3x3s.append(
+                                nn.Sequential(
+                                    nn.Conv2d(num_inchannels[j], num_outchannels_conv3x3, 3, 2, 1, bias=False),
+                                    BatchNorm2d(num_outchannels_conv3x3, momentum=BN_MOMENTUM),
+                                )
+                            )
                         else:
                             num_outchannels_conv3x3 = num_inchannels[j]
-                            conv3x3s.append(nn.Sequential(
-                                nn.Conv2d(num_inchannels[j],
-                                          num_outchannels_conv3x3,
-                                          3, 2, 1, bias=False),
-                                BatchNorm2d(num_outchannels_conv3x3,
-                                            momentum=BN_MOMENTUM),
-                                nn.ReLU(inplace=True)))
+                            conv3x3s.append(
+                                nn.Sequential(
+                                    nn.Conv2d(num_inchannels[j], num_outchannels_conv3x3, 3, 2, 1, bias=False),
+                                    BatchNorm2d(num_outchannels_conv3x3, momentum=BN_MOMENTUM),
+                                    nn.ReLU(inplace=True),
+                                )
+                            )
                     fuse_layer.append(nn.Sequential(*conv3x3s))
             fuse_layers.append(nn.ModuleList(fuse_layer))
 
@@ -255,9 +244,8 @@ class HighResolutionModule(nn.Module):
                     width_output = x[i].shape[-1]
                     height_output = x[i].shape[-2]
                     y = y + F.interpolate(
-                        self.fuse_layers[i][j](x[j]),
-                        size=[height_output, width_output],
-                        mode='bilinear')
+                        self.fuse_layers[i][j](x[j]), size=[height_output, width_output], mode="bilinear"
+                    )
                 else:
                     y = y + self.fuse_layers[i][j](x[j])
             x_fuse.append(self.relu(y))
@@ -265,14 +253,10 @@ class HighResolutionModule(nn.Module):
         return x_fuse
 
 
-blocks_dict = {
-    'BASIC': BasicBlock,
-    'BOTTLENECK': Bottleneck
-}
+blocks_dict = {"BASIC": BasicBlock, "BOTTLENECK": Bottleneck}
 
 
 class HighResolutionNet(nn.Module):
-
     def __init__(self, config, criterion, n_classes, **kwargs):
         extra = config.MODEL.EXTRA
         super(HighResolutionNet, self).__init__()
@@ -282,60 +266,46 @@ class HighResolutionNet(nn.Module):
         self.n_classes = n_classes
 
         # stem net
-        self.conv1 = nn.Conv2d(3, 64, kernel_size=3, stride=2, padding=1,
-                               bias=False)
+        self.conv1 = nn.Conv2d(3, 64, kernel_size=3, stride=2, padding=1, bias=False)
         self.bn1 = BatchNorm2d(64, momentum=BN_MOMENTUM)
-        self.conv2 = nn.Conv2d(64, 64, kernel_size=3, stride=2, padding=1,
-                               bias=False)
+        self.conv2 = nn.Conv2d(64, 64, kernel_size=3, stride=2, padding=1, bias=False)
         self.bn2 = BatchNorm2d(64, momentum=BN_MOMENTUM)
         self.relu = nn.ReLU(inplace=True)
-        
-        self.stage1_cfg = extra['STAGE1']
-        num_channels = self.stage1_cfg['NUM_CHANNELS'][0]
-        block = blocks_dict[self.stage1_cfg['BLOCK']]
-        num_blocks = self.stage1_cfg['NUM_BLOCKS'][0]
+
+        self.stage1_cfg = extra["STAGE1"]
+        num_channels = self.stage1_cfg["NUM_CHANNELS"][0]
+        block = blocks_dict[self.stage1_cfg["BLOCK"]]
+        num_blocks = self.stage1_cfg["NUM_BLOCKS"][0]
         self.layer1 = self._make_layer(block, 64, num_channels, num_blocks)
-        stage1_out_channel = block.expansion*num_channels
+        stage1_out_channel = block.expansion * num_channels
 
-        self.stage2_cfg = extra['STAGE2']
-        num_channels = self.stage2_cfg['NUM_CHANNELS']
-        block = blocks_dict[self.stage2_cfg['BLOCK']]
-        num_channels = [
-            num_channels[i] * block.expansion for i in range(len(num_channels))]
-        self.transition1 = self._make_transition_layer(
-            [stage1_out_channel], num_channels)
-        self.stage2, pre_stage_channels = self._make_stage(
-            self.stage2_cfg, num_channels)
+        self.stage2_cfg = extra["STAGE2"]
+        num_channels = self.stage2_cfg["NUM_CHANNELS"]
+        block = blocks_dict[self.stage2_cfg["BLOCK"]]
+        num_channels = [num_channels[i] * block.expansion for i in range(len(num_channels))]
+        self.transition1 = self._make_transition_layer([stage1_out_channel], num_channels)
+        self.stage2, pre_stage_channels = self._make_stage(self.stage2_cfg, num_channels)
 
-        self.stage3_cfg = extra['STAGE3']
-        num_channels = self.stage3_cfg['NUM_CHANNELS']
-        block = blocks_dict[self.stage3_cfg['BLOCK']]
-        num_channels = [
-            num_channels[i] * block.expansion for i in range(len(num_channels))]
-        self.transition2 = self._make_transition_layer(
-            pre_stage_channels, num_channels)
-        self.stage3, pre_stage_channels = self._make_stage(
-            self.stage3_cfg, num_channels)
+        self.stage3_cfg = extra["STAGE3"]
+        num_channels = self.stage3_cfg["NUM_CHANNELS"]
+        block = blocks_dict[self.stage3_cfg["BLOCK"]]
+        num_channels = [num_channels[i] * block.expansion for i in range(len(num_channels))]
+        self.transition2 = self._make_transition_layer(pre_stage_channels, num_channels)
+        self.stage3, pre_stage_channels = self._make_stage(self.stage3_cfg, num_channels)
 
-        self.stage4_cfg = extra['STAGE4']
-        num_channels = self.stage4_cfg['NUM_CHANNELS']
-        block = blocks_dict[self.stage4_cfg['BLOCK']]
-        num_channels = [
-            num_channels[i] * block.expansion for i in range(len(num_channels))]
-        self.transition3 = self._make_transition_layer(
-            pre_stage_channels, num_channels)
-        self.stage4, pre_stage_channels = self._make_stage(
-            self.stage4_cfg, num_channels, multi_scale_output=True)
-        
+        self.stage4_cfg = extra["STAGE4"]
+        num_channels = self.stage4_cfg["NUM_CHANNELS"]
+        block = blocks_dict[self.stage4_cfg["BLOCK"]]
+        num_channels = [num_channels[i] * block.expansion for i in range(len(num_channels))]
+        self.transition3 = self._make_transition_layer(pre_stage_channels, num_channels)
+        self.stage4, pre_stage_channels = self._make_stage(self.stage4_cfg, num_channels, multi_scale_output=True)
+
         last_inp_channels = np.int(np.sum(pre_stage_channels))
 
         self.last_layer = nn.Sequential(
             nn.Conv2d(
-                in_channels=last_inp_channels,
-                out_channels=last_inp_channels,
-                kernel_size=1,
-                stride=1,
-                padding=0),
+                in_channels=last_inp_channels, out_channels=last_inp_channels, kernel_size=1, stride=1, padding=0
+            ),
             BatchNorm2d(last_inp_channels, momentum=BN_MOMENTUM),
             nn.ReLU(inplace=True),
             nn.Conv2d(
@@ -344,11 +314,11 @@ class HighResolutionNet(nn.Module):
                 out_channels=self.n_classes,
                 kernel_size=extra.FINAL_CONV_KERNEL,
                 stride=1,
-                padding=1 if extra.FINAL_CONV_KERNEL == 3 else 0)
+                padding=1 if extra.FINAL_CONV_KERNEL == 3 else 0,
+            ),
         )
 
-    def _make_transition_layer(
-            self, num_channels_pre_layer, num_channels_cur_layer):
+    def _make_transition_layer(self, num_channels_pre_layer, num_channels_cur_layer):
         """
         Use 3x3 convolutions, with stride 2 and padding 1.
         """
@@ -359,34 +329,32 @@ class HighResolutionNet(nn.Module):
         for i in range(num_branches_cur):
             if i < num_branches_pre:
                 if num_channels_cur_layer[i] != num_channels_pre_layer[i]:
-                    transition_layers.append(nn.Sequential(
-                        nn.Conv2d(num_channels_pre_layer[i],
-                                  num_channels_cur_layer[i],
-                                  3,
-                                  1,
-                                  1,
-                                  bias=False),
-                        BatchNorm2d(
-                            num_channels_cur_layer[i], momentum=BN_MOMENTUM),
-                        nn.ReLU(inplace=True)))
+                    transition_layers.append(
+                        nn.Sequential(
+                            nn.Conv2d(num_channels_pre_layer[i], num_channels_cur_layer[i], 3, 1, 1, bias=False),
+                            BatchNorm2d(num_channels_cur_layer[i], momentum=BN_MOMENTUM),
+                            nn.ReLU(inplace=True),
+                        )
+                    )
                 else:
                     transition_layers.append(None)
             else:
                 conv3x3s = []
-                for j in range(i+1-num_branches_pre):
+                for j in range(i + 1 - num_branches_pre):
                     inchannels = num_channels_pre_layer[-1]
-                    outchannels = num_channels_cur_layer[i] \
-                        if j == i-num_branches_pre else inchannels
-                    conv3x3s.append(nn.Sequential(
-                        nn.Conv2d(
-                            inchannels, outchannels, 3, 2, 1, bias=False),
-                        BatchNorm2d(outchannels, momentum=BN_MOMENTUM),
-                        nn.ReLU(inplace=True)))
+                    outchannels = num_channels_cur_layer[i] if j == i - num_branches_pre else inchannels
+                    conv3x3s.append(
+                        nn.Sequential(
+                            nn.Conv2d(inchannels, outchannels, 3, 2, 1, bias=False),
+                            BatchNorm2d(outchannels, momentum=BN_MOMENTUM),
+                            nn.ReLU(inplace=True),
+                        )
+                    )
                 transition_layers.append(nn.Sequential(*conv3x3s))
 
         return nn.ModuleList(transition_layers)
 
-    def _make_layer(self, block, inplanes: int, planes: int, blocks: int, stride: int=1):
+    def _make_layer(self, block, inplanes: int, planes: int, blocks: int, stride: int = 1):
         """
         Identical to ResNet `_make_layer()`, except `inplanes` is an
         explicit argument rather than class attribute, and batch norm
@@ -395,8 +363,7 @@ class HighResolutionNet(nn.Module):
         downsample = None
         if stride != 1 or inplanes != planes * block.expansion:
             downsample = nn.Sequential(
-                nn.Conv2d(inplanes, planes * block.expansion,
-                          kernel_size=1, stride=stride, bias=False),
+                nn.Conv2d(inplanes, planes * block.expansion, kernel_size=1, stride=stride, bias=False),
                 BatchNorm2d(planes * block.expansion, momentum=BN_MOMENTUM),
             )
 
@@ -408,14 +375,13 @@ class HighResolutionNet(nn.Module):
 
         return nn.Sequential(*layers)
 
-    def _make_stage(self, layer_config, num_inchannels,
-                    multi_scale_output=True):
-        num_modules = layer_config['NUM_MODULES']
-        num_branches = layer_config['NUM_BRANCHES']
-        num_blocks = layer_config['NUM_BLOCKS']
-        num_channels = layer_config['NUM_CHANNELS']
-        block = blocks_dict[layer_config['BLOCK']]
-        fuse_method = layer_config['FUSE_METHOD']
+    def _make_stage(self, layer_config, num_inchannels, multi_scale_output=True):
+        num_modules = layer_config["NUM_MODULES"]
+        num_branches = layer_config["NUM_BRANCHES"]
+        num_blocks = layer_config["NUM_BLOCKS"]
+        num_channels = layer_config["NUM_CHANNELS"]
+        block = blocks_dict[layer_config["BLOCK"]]
+        fuse_method = layer_config["FUSE_METHOD"]
 
         modules = []
         for i in range(num_modules):
@@ -425,13 +391,9 @@ class HighResolutionNet(nn.Module):
             else:
                 reset_multi_scale_output = True
             modules.append(
-                HighResolutionModule(num_branches,
-                                      block,
-                                      num_blocks,
-                                      num_inchannels,
-                                      num_channels,
-                                      fuse_method,
-                                      reset_multi_scale_output)
+                HighResolutionModule(
+                    num_branches, block, num_blocks, num_inchannels, num_channels, fuse_method, reset_multi_scale_output
+                )
             )
             num_inchannels = modules[-1].get_num_inchannels()
 
@@ -439,18 +401,18 @@ class HighResolutionNet(nn.Module):
 
     def forward(self, x, y=None):
         """
-        Network starts from a stem of two strided 3 × 3 convolutions 
+        Network starts from a stem of two strided 3 × 3 convolutions
         decreasing the resolution to 1/4.
 
-        Rescale the low-resolution representations through bilinear 
-        upsampling to the high resolution, and concatenate the subsets 
+        Rescale the low-resolution representations through bilinear
+        upsampling to the high resolution, and concatenate the subsets
         of such representations.
 
-        At end, the segmentation maps are upsampled (4 times) to the 
+        At end, the segmentation maps are upsampled (4 times) to the
         input size by bilinear upsampling for both training and testing.
         """
         x_size = x.size()
-        assert (x_size[2]-1) % 8 == 0 and (x_size[3]-1) % 8 == 0
+        assert (x_size[2] - 1) % 8 == 0 and (x_size[3] - 1) % 8 == 0
         # h = int((x_size[2] - 1) / 8 * self.zoom_factor + 1)
         h = x_size[2]
         w = x_size[3]
@@ -465,7 +427,7 @@ class HighResolutionNet(nn.Module):
         x = self.layer1(x)
 
         x_list = []
-        for i in range(self.stage2_cfg['NUM_BRANCHES']):
+        for i in range(self.stage2_cfg["NUM_BRANCHES"]):
             if self.transition1[i] is not None:
                 x_list.append(self.transition1[i](x))
             else:
@@ -473,7 +435,7 @@ class HighResolutionNet(nn.Module):
         y_list = self.stage2(x_list)
 
         x_list = []
-        for i in range(self.stage3_cfg['NUM_BRANCHES']):
+        for i in range(self.stage3_cfg["NUM_BRANCHES"]):
             if self.transition2[i] is not None:
                 x_list.append(self.transition2[i](y_list[-1]))
             else:
@@ -481,7 +443,7 @@ class HighResolutionNet(nn.Module):
         y_list = self.stage3(x_list)
 
         x_list = []
-        for i in range(self.stage4_cfg['NUM_BRANCHES']):
+        for i in range(self.stage4_cfg["NUM_BRANCHES"]):
             if self.transition3[i] is not None:
                 x_list.append(self.transition3[i](y_list[-1]))
             else:
@@ -490,16 +452,16 @@ class HighResolutionNet(nn.Module):
 
         # Upsampling
         x0_h, x0_w = x[0].size(2), x[0].size(3)
-        x1 = F.upsample(x[1], size=(x0_h, x0_w), mode='bilinear')
-        x2 = F.upsample(x[2], size=(x0_h, x0_w), mode='bilinear')
-        x3 = F.upsample(x[3], size=(x0_h, x0_w), mode='bilinear')
+        x1 = F.upsample(x[1], size=(x0_h, x0_w), mode="bilinear")
+        x2 = F.upsample(x[2], size=(x0_h, x0_w), mode="bilinear")
+        x3 = F.upsample(x[3], size=(x0_h, x0_w), mode="bilinear")
 
         x = torch.cat([x[0], x1, x2, x3], 1)
         # Perform two 1x1 convolutions on concat representation
         x = self.last_layer(x)
 
         # Bilinear upsampling of output
-        x = F.interpolate(x, size=(h,w), mode='bilinear', align_corners=True)
+        x = F.interpolate(x, size=(h, w), mode="bilinear", align_corners=True)
         if self.training:
             main_loss = self.criterion(x, y)
             return x.max(1)[1], main_loss, main_loss * 0
@@ -508,15 +470,13 @@ class HighResolutionNet(nn.Module):
 
         # return x
 
-    def init_weights(self, load_imagenet_model: bool=False, imagenet_ckpt_fpath: str='') -> None:
-        """ For training, we use a model pretrained on ImageNet. Irrelevant at inference.
-            Args:
-            -   pretrained_fpath: str representing path to pretrained model
-
-            Returns:
-            -   None
+    def init_weights(self, load_imagenet_model: bool = False, imagenet_ckpt_fpath: str = "") -> None:
+        """For training, we use a model pretrained on ImageNet. Irrelevant at inference.
+        Args:
+            load_imagenet_model: 
+            imagenet_ckpt_fpath: str representing path to pretrained model.
         """
-        logger.info('=> init weights from normal distribution')
+        logger.info("=> init weights from normal distribution")
         for m in self.modules():
             if isinstance(m, nn.Conv2d):
                 nn.init.normal_(m.weight, std=0.001)
@@ -527,57 +487,53 @@ class HighResolutionNet(nn.Module):
             return
         if os.path.isfile(imagenet_ckpt_fpath):
             pretrained_dict = torch.load(imagenet_ckpt_fpath)
-            logger.info('=> loading pretrained model {}'.format(imagenet_ckpt_fpath))
+            logger.info("=> loading pretrained model {}".format(imagenet_ckpt_fpath))
             model_dict = self.state_dict()
-            pretrained_dict = {
-                k: v for k, v in pretrained_dict.items() if k in model_dict.keys()
-            }
-            #for k, _ in pretrained_dict.items():
+            pretrained_dict = {k: v for k, v in pretrained_dict.items() if k in model_dict.keys()}
+            # for k, _ in pretrained_dict.items():
             #    logger.info(
             #        '=> loading {} pretrained model {}'.format(k, pretrained))
             model_dict.update(pretrained_dict)
             self.load_state_dict(model_dict)
         else:
             # logger.info(pretrained)
-            logger.info('cannot find ImageNet model path, use random initialization')
-            raise Exception('no pretrained model found at {}'.format(imagenet_ckpt_fpath))
+            logger.info("cannot find ImageNet model path, use random initialization")
+            raise Exception("no pretrained model found at {}".format(imagenet_ckpt_fpath))
+
 
 def get_seg_model(
-    cfg,
-    criterion,
-    n_classes: int,
-    load_imagenet_model: bool = False,
-    imagenet_ckpt_fpath: str = '',
-    **kwargs
-    ) -> nn.Module:
+    cfg, criterion, n_classes: int, load_imagenet_model: bool = False, imagenet_ckpt_fpath: str = "", **kwargs
+) -> nn.Module:
     model = HighResolutionNet(cfg, criterion, n_classes, **kwargs)
     model.init_weights(load_imagenet_model, imagenet_ckpt_fpath)
     assert isinstance(model, nn.Module)
     return model
 
+
 def get_configured_hrnet(
     n_classes: int,
     load_imagenet_model: bool = False,
-    imagenet_ckpt_fpath: str = '',
-    ) -> nn.Module:
+    imagenet_ckpt_fpath: str = "",
+) -> nn.Module:
     """
-        Args:
-        -   n_classes: integer representing number of output classes
-        -   load_imagenet_model: whether to initialize from ImageNet-pretrained model
-        -   imagenet_ckpt_fpath: string representing path to file with weights to 
-                initialize model with
+    Args:
+        n_classes: integer representing number of output classes.
+        load_imagenet_model: whether to initialize from ImageNet-pretrained model.
+        imagenet_ckpt_fpath: string representing path to file with weights to
+            initialize model with.
 
-        Returns:
-        -   model: HRNet model w/ architecture configured according to model yaml,
-                and with specified number of classes and weights initialized
-                (at training, init using imagenet-pretrained model)
+    Returns:
+        model: HRNet model w/ architecture configured according to model yaml,
+            and with specified number of classes and weights initialized
+            (at training, init using imagenet-pretrained model).
     """
     from yacs.config import CfgNode as CN
+
     _C = CN()
 
     # common params for NETWORK
     _C.MODEL = CN()
-    _C.MODEL.NAME = 'seg_hrnet'
+    _C.MODEL.NAME = "seg_hrnet"
     _C.MODEL.EXTRA = CN(new_allowed=True)
 
     # training
@@ -588,7 +544,7 @@ def get_configured_hrnet(
     _C.TEST = CN()
     _C.TEST.MULTI_SCALE = False
 
-    _C.merge_from_file(f'{_ROOT}/seg_hrnet.yaml')
+    _C.merge_from_file(f"{_ROOT}/seg_hrnet.yaml")
     config = _C
 
     criterion = nn.CrossEntropyLoss(ignore_index=255)
@@ -596,11 +552,11 @@ def get_configured_hrnet(
     return model
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     """ """
-    imagenet_ckpt_fpath = ''
+    import pdb; pdb.set_trace()
+    imagenet_ckpt_fpath = ""
     load_imagenet_model = False
     model = get_configured_hrnet(180, load_imagenet_model, imagenet_ckpt_fpath)
     num_p = sum(p.numel() for p in model.parameters() if p.requires_grad)
     print(num_p)
-

--- a/mseg_semantic/model/seg_hrnet.py
+++ b/mseg_semantic/model/seg_hrnet.py
@@ -28,7 +28,6 @@ from omegaconf import OmegaConf
 
 from mseg_semantic.model.seg_hrnet_config import HRNetArchConfig, HRNetStageConfig
 
-import pdb
 
 BatchNorm2d = torch.nn.SyncBatchNorm
 BN_MOMENTUM = 0.01
@@ -134,9 +133,6 @@ class HighResolutionModule(nn.Module):
         multi_scale_output: bool = True,
     ) -> None:
         """ """
-        import pdb
-
-        pdb.set_trace()
         super(HighResolutionModule, self).__init__()
         self._check_branches(
             num_branches=num_branches, num_blocks=num_blocks, num_inchannels=num_inchannels, num_channels=num_channels
@@ -259,9 +255,11 @@ class HighResolutionModule(nn.Module):
         return nn.ModuleList(fuse_layers)
 
     def get_num_inchannels(self):
+        import pdb; pdb.set_trace()
         return self.num_inchannels
 
     def forward(self, x):
+        import pdb; pdb.set_trace()
         if self.num_branches == 1:
             return [self.branches[0](x[0])]
 
@@ -284,6 +282,7 @@ class HighResolutionModule(nn.Module):
                     y = y + self.fuse_layers[i][j](x[j])
             x_fuse.append(self.relu(y))
 
+        import pdb; pdb.set_trace()
         return x_fuse
 
 
@@ -395,6 +394,7 @@ class HighResolutionNet(nn.Module):
         explicit argument rather than class attribute, and batch norm
         implementation and momentum are hardcoded.
         """
+        import pdb; pdb.set_trace()
         downsample = None
         if stride != 1 or inplanes != planes * block.expansion:
             downsample = nn.Sequential(

--- a/mseg_semantic/model/seg_hrnet.py
+++ b/mseg_semantic/model/seg_hrnet.py
@@ -257,7 +257,7 @@ class HighResolutionModule(nn.Module):
     def get_num_inchannels(self) -> List[int]:
         return self.num_inchannels
 
-    def forward(self, x: List[torch.Tensor]):
+    def forward(self, x: List[torch.Tensor]) -> List[torch.Tensor]:
         """
         Args:
             x: list of Pytorch tensors.
@@ -265,10 +265,6 @@ class HighResolutionModule(nn.Module):
         Returns:
             x_fuse: 
         """
-        print("forward x shape: ", len(x))
-        for x_ in x:
-            print("shape: ", x_.shape)
-
         if self.num_branches == 1:
             return [self.branches[0](x[0])]
 
@@ -291,9 +287,6 @@ class HighResolutionModule(nn.Module):
                     y = y + self.fuse_layers[i][j](x[j])
             x_fuse.append(self.relu(y))
 
-        print("end forward x_fuse shape: ", len(x_fuse))
-        for x_ in x_fuse:
-            print("shape: ", x_.shape)
         return x_fuse
 
 

--- a/mseg_semantic/model/seg_hrnet.py
+++ b/mseg_semantic/model/seg_hrnet.py
@@ -267,7 +267,6 @@ blocks_dict = {"BASIC": BasicBlock, "BOTTLENECK": Bottleneck}
 class HighResolutionNet(nn.Module):
     def __init__(self, config: HRNetArchConfig, criterion: nn.Module, n_classes: int) -> None:
         """ """
-        extra = config.MODEL.EXTRA
         super(HighResolutionNet, self).__init__()
 
         self.criterion = criterion
@@ -280,28 +279,28 @@ class HighResolutionNet(nn.Module):
         self.bn2 = BatchNorm2d(64, momentum=BN_MOMENTUM)
         self.relu = nn.ReLU(inplace=True)
 
-        self.stage1_cfg = extra.STAGE1
+        self.stage1_cfg = config.STAGE1
         num_channels = self.stage1_cfg.NUM_CHANNELS[0]
         block = blocks_dict[self.stage1_cfg.BLOCK]
         num_blocks = self.stage1_cfg.NUM_BLOCKS[0]
         self.layer1 = self._make_layer(block, 64, num_channels, num_blocks)
         stage1_out_channel = block.expansion * num_channels
 
-        self.stage2_cfg = extra.STAGE2
+        self.stage2_cfg = config.STAGE2
         num_channels = self.stage2_cfg.NUM_CHANNELS
         block = blocks_dict[self.stage2_cfg.BLOCK]
         num_channels = [num_channels[i] * block.expansion for i in range(len(num_channels))]
         self.transition1 = self._make_transition_layer([stage1_out_channel], num_channels)
         self.stage2, pre_stage_channels = self._make_stage(self.stage2_cfg, num_channels)
 
-        self.stage3_cfg = extra.STAGE3
+        self.stage3_cfg = config.STAGE3
         num_channels = self.stage3_cfg.NUM_CHANNELS
         block = blocks_dict[self.stage3_cfg.BLOCK]
         num_channels = [num_channels[i] * block.expansion for i in range(len(num_channels))]
         self.transition2 = self._make_transition_layer(pre_stage_channels, num_channels)
         self.stage3, pre_stage_channels = self._make_stage(self.stage3_cfg, num_channels)
 
-        self.stage4_cfg = extra.STAGE4
+        self.stage4_cfg = config.STAGE4
         num_channels = self.stage4_cfg.NUM_CHANNELS
         block = blocks_dict[self.stage4_cfg.BLOCK]
         num_channels = [num_channels[i] * block.expansion for i in range(len(num_channels))]
@@ -320,9 +319,9 @@ class HighResolutionNet(nn.Module):
                 in_channels=last_inp_channels,
                 # out_channels=config.DATASET.NUM_CLASSES,
                 out_channels=self.n_classes,
-                kernel_size=extra.FINAL_CONV_KERNEL,
+                kernel_size=config.FINAL_CONV_KERNEL,
                 stride=1,
-                padding=1 if extra.FINAL_CONV_KERNEL == 3 else 0,
+                padding=1 if config.FINAL_CONV_KERNEL == 3 else 0,
             ),
         )
 

--- a/mseg_semantic/model/seg_hrnet.py
+++ b/mseg_semantic/model/seg_hrnet.py
@@ -8,6 +8,7 @@ import os
 import logging
 import functools
 from pathlib import Path
+from typing import List, Optional
 
 import numpy as np
 import torch
@@ -32,7 +33,7 @@ logger = logging.getLogger(__name__)
 _ROOT = Path(__file__).resolve().parent
 
 
-def conv3x3(in_planes, out_planes, stride=1):
+def conv3x3(in_planes: int, out_planes: int, stride: int = 1) -> nn.Module:
     """3x3 convolution with padding"""
     return nn.Conv2d(in_planes, out_planes, kernel_size=3, stride=stride, padding=1, bias=False)
 
@@ -45,7 +46,7 @@ class BasicBlock(nn.Module):
 
     expansion = 1
 
-    def __init__(self, inplanes, planes, stride=1, downsample=None):
+    def __init__(self, inplanes: int, planes: int, stride: int = 1, downsample=None) -> None:
         super(BasicBlock, self).__init__()
         self.conv1 = conv3x3(inplanes, planes, stride)
         self.bn1 = BatchNorm2d(planes, momentum=BN_MOMENTUM)
@@ -55,7 +56,7 @@ class BasicBlock(nn.Module):
         self.downsample = downsample
         self.stride = stride
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         residual = x
 
         out = self.conv1(x)
@@ -82,7 +83,7 @@ class Bottleneck(nn.Module):
 
     expansion = 4
 
-    def __init__(self, inplanes, planes, stride=1, downsample=None):
+    def __init__(self, inplanes: int, planes: int, stride: int = 1, downsample=None) -> None:
         super(Bottleneck, self).__init__()
         self.conv1 = nn.Conv2d(inplanes, planes, kernel_size=1, bias=False)
         self.bn1 = BatchNorm2d(planes, momentum=BN_MOMENTUM)
@@ -94,7 +95,7 @@ class Bottleneck(nn.Module):
         self.downsample = downsample
         self.stride = stride
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         residual = x
 
         out = self.conv1(x)
@@ -135,6 +136,7 @@ class HighResolutionModule(nn.Module):
         self.relu = nn.ReLU(inplace=True)
 
     def _check_branches(self, num_branches, blocks, num_blocks, num_inchannels, num_channels):
+        """ """
         if num_branches != len(num_blocks):
             error_msg = "NUM_BRANCHES({}) <> NUM_BLOCKS({})".format(num_branches, len(num_blocks))
             logger.error(error_msg)
@@ -257,7 +259,7 @@ blocks_dict = {"BASIC": BasicBlock, "BOTTLENECK": Bottleneck}
 
 
 class HighResolutionNet(nn.Module):
-    def __init__(self, config, criterion, n_classes, **kwargs):
+    def __init__(self, config, criterion, n_classes: int, **kwargs):
         extra = config.MODEL.EXTRA
         super(HighResolutionNet, self).__init__()
 
@@ -318,7 +320,7 @@ class HighResolutionNet(nn.Module):
             ),
         )
 
-    def _make_transition_layer(self, num_channels_pre_layer, num_channels_cur_layer):
+    def _make_transition_layer(self, num_channels_pre_layer: List[int], num_channels_cur_layer: List[int]):
         """
         Use 3x3 convolutions, with stride 2 and padding 1.
         """
@@ -399,7 +401,7 @@ class HighResolutionNet(nn.Module):
 
         return nn.Sequential(*modules), num_inchannels
 
-    def forward(self, x, y=None):
+    def forward(self, x: torch.Tensor, y: Optional[torch.Tensor] = None):
         """
         Network starts from a stem of two strided 3 × 3 convolutions
         decreasing the resolution to 1/4.

--- a/mseg_semantic/model/seg_hrnet.py
+++ b/mseg_semantic/model/seg_hrnet.py
@@ -126,7 +126,7 @@ class HighResolutionModule(nn.Module):
     def __init__(
         self,
         num_branches: int,
-        blocks: Union[BasicBlock, Bottleneck],
+        block: Union[BasicBlock, Bottleneck],
         num_blocks: List[int],
         num_inchannels: List[int],
         num_channels: List[int],
@@ -138,7 +138,9 @@ class HighResolutionModule(nn.Module):
 
         pdb.set_trace()
         super(HighResolutionModule, self).__init__()
-        self._check_branches(num_branches, blocks, num_blocks, num_inchannels, num_channels)
+        self._check_branches(
+            num_branches=num_branches, num_blocks=num_blocks, num_inchannels=num_inchannels, num_channels=num_channels
+        )
 
         self.num_inchannels = num_inchannels
         self.fuse_method = fuse_method
@@ -146,12 +148,14 @@ class HighResolutionModule(nn.Module):
 
         self.multi_scale_output = multi_scale_output
 
-        self.branches = self._make_branches(num_branches, blocks, num_blocks, num_channels)
+        self.branches = self._make_branches(
+            num_branches=num_branches, block=block, num_blocks=num_blocks, num_channels=num_channels
+        )
         self.fuse_layers = self._make_fuse_layers()
         self.relu = nn.ReLU(inplace=True)
 
     def _check_branches(
-        self, num_branches: int, blocks, num_blocks: List[int], num_inchannels: List[int], num_channels: List[int]
+        self, num_branches: int, num_blocks: List[int], num_inchannels: List[int], num_channels: List[int]
     ) -> None:
         """ """
         if num_branches != len(num_blocks):
@@ -209,7 +213,8 @@ class HighResolutionModule(nn.Module):
 
         return nn.ModuleList(branches)
 
-    def _make_fuse_layers(self):
+    def _make_fuse_layers(self) -> nn.ModuleList:
+        """ """
         if self.num_branches == 1:
             return None
 

--- a/mseg_semantic/model/seg_hrnet.py
+++ b/mseg_semantic/model/seg_hrnet.py
@@ -542,7 +542,7 @@ def get_configured_hrnet(
         cfg = hydra.compose(config_name="seg_hrnet.yaml")
         logger.info("Using config: ")
         logger.info(OmegaConf.to_yaml(cfg))
-        config: HRNetArchConfig = instantiate(cfg.SceneOptimizer)
+        config: HRNetArchConfig = instantiate(cfg.HRNetArchConfig)
 
     criterion = nn.CrossEntropyLoss(ignore_index=255)
     model = get_seg_model(config, criterion, n_classes, load_imagenet_model, imagenet_ckpt_fpath)

--- a/mseg_semantic/model/seg_hrnet.py
+++ b/mseg_semantic/model/seg_hrnet.py
@@ -263,7 +263,7 @@ class HighResolutionModule(nn.Module):
             x: list of Pytorch tensors.
 
         Returns:
-            x_fuse:
+            x_fuse: list of Pytorch tensors.
         """
         if self.num_branches == 1:
             return [self.branches[0](x[0])]

--- a/mseg_semantic/model/seg_hrnet.py
+++ b/mseg_semantic/model/seg_hrnet.py
@@ -258,7 +258,10 @@ class HighResolutionModule(nn.Module):
         return self.num_inchannels
 
     def forward(self, x):
-        print("forward x shape: ", x.shape, x.dtype)
+        print("forward x shape: ", len(x))
+        for x_ in x:
+            print("shape: ", x_.shape)
+
         if self.num_branches == 1:
             return [self.branches[0](x[0])]
 

--- a/mseg_semantic/model/seg_hrnet.py
+++ b/mseg_semantic/model/seg_hrnet.py
@@ -257,7 +257,14 @@ class HighResolutionModule(nn.Module):
     def get_num_inchannels(self) -> List[int]:
         return self.num_inchannels
 
-    def forward(self, x):
+    def forward(self, x: List[torch.Tensor]):
+        """
+        Args:
+            x: list of Pytorch tensors.
+
+        Returns:
+            x_fuse: 
+        """
         print("forward x shape: ", len(x))
         for x_ in x:
             print("shape: ", x_.shape)
@@ -284,7 +291,9 @@ class HighResolutionModule(nn.Module):
                     y = y + self.fuse_layers[i][j](x[j])
             x_fuse.append(self.relu(y))
 
-        print("end forward x_fuse shape: ", x_fuse.shape, x_fuse.dtype)
+        print("end forward x_fuse shape: ", len(x_fuse))
+        for x_ in x_fuse:
+            print("shape: ", x_.shape)
         return x_fuse
 
 

--- a/mseg_semantic/model/seg_hrnet.py
+++ b/mseg_semantic/model/seg_hrnet.py
@@ -263,7 +263,7 @@ class HighResolutionModule(nn.Module):
             x: list of Pytorch tensors.
 
         Returns:
-            x_fuse: 
+            x_fuse:
         """
         if self.num_branches == 1:
             return [self.branches[0](x[0])]
@@ -391,7 +391,9 @@ class HighResolutionNet(nn.Module):
 
         return nn.ModuleList(transition_layers)
 
-    def _make_layer(self, block: Union[BasicBlock, Bottleneck], inplanes: int, planes: int, blocks: int, stride: int = 1) -> nn.Module:
+    def _make_layer(
+        self, block: Union[BasicBlock, Bottleneck], inplanes: int, planes: int, blocks: int, stride: int = 1
+    ) -> nn.Module:
         """
         Identical to ResNet `_make_layer()`, except `inplanes` is an
         explicit argument rather than class attribute, and batch norm

--- a/mseg_semantic/model/seg_hrnet.py
+++ b/mseg_semantic/model/seg_hrnet.py
@@ -254,12 +254,11 @@ class HighResolutionModule(nn.Module):
 
         return nn.ModuleList(fuse_layers)
 
-    def get_num_inchannels(self):
-        import pdb; pdb.set_trace()
+    def get_num_inchannels(self) -> List[int]:
         return self.num_inchannels
 
     def forward(self, x):
-        import pdb; pdb.set_trace()
+        print("forward x shape: ", x.shape, x.dtype)
         if self.num_branches == 1:
             return [self.branches[0](x[0])]
 
@@ -282,7 +281,7 @@ class HighResolutionModule(nn.Module):
                     y = y + self.fuse_layers[i][j](x[j])
             x_fuse.append(self.relu(y))
 
-        import pdb; pdb.set_trace()
+        print("end forward x_fuse shape: ", x_fuse.shape, x_fuse.dtype)
         return x_fuse
 
 
@@ -342,7 +341,6 @@ class HighResolutionNet(nn.Module):
             nn.ReLU(inplace=True),
             nn.Conv2d(
                 in_channels=last_inp_channels,
-                # out_channels=config.DATASET.NUM_CLASSES,
                 out_channels=self.n_classes,
                 kernel_size=config.FINAL_CONV_KERNEL,
                 stride=1,
@@ -388,13 +386,12 @@ class HighResolutionNet(nn.Module):
 
         return nn.ModuleList(transition_layers)
 
-    def _make_layer(self, block, inplanes: int, planes: int, blocks: int, stride: int = 1) -> nn.Module:
+    def _make_layer(self, block: Union[BasicBlock, Bottleneck], inplanes: int, planes: int, blocks: int, stride: int = 1) -> nn.Module:
         """
         Identical to ResNet `_make_layer()`, except `inplanes` is an
         explicit argument rather than class attribute, and batch norm
         implementation and momentum are hardcoded.
         """
-        import pdb; pdb.set_trace()
         downsample = None
         if stride != 1 or inplanes != planes * block.expansion:
             downsample = nn.Sequential(

--- a/mseg_semantic/model/seg_hrnet.yaml
+++ b/mseg_semantic/model/seg_hrnet.yaml
@@ -1,52 +1,39 @@
-MODEL:
-  NAME: seg_hrnet
-  EXTRA:
-    FINAL_CONV_KERNEL: 1
-    STAGE1:
-      NUM_MODULES: 1
-      NUM_RANCHES: 1
-      BLOCK: BOTTLENECK
-      NUM_BLOCKS:
-      - 4
-      NUM_CHANNELS:
-      - 64
-      FUSE_METHOD: SUM
-    STAGE2:
-      NUM_MODULES: 1
-      NUM_BRANCHES: 2
-      BLOCK: BASIC
-      NUM_BLOCKS:
-      - 4
-      - 4
-      NUM_CHANNELS:
-      - 48
-      - 96
-      FUSE_METHOD: SUM
-    STAGE3:
-      NUM_MODULES: 4
-      NUM_BRANCHES: 3
-      BLOCK: BASIC
-      NUM_BLOCKS:
-      - 4
-      - 4
-      - 4
-      NUM_CHANNELS:
-      - 48
-      - 96
-      - 192
-      FUSE_METHOD: SUM
-    STAGE4:
-      NUM_MODULES: 3
-      NUM_BRANCHES: 4
-      BLOCK: BASIC
-      NUM_BLOCKS:
-      - 4
-      - 4
-      - 4
-      - 4
-      NUM_CHANNELS:
-      - 48
-      - 96
-      - 192
-      - 384
-      FUSE_METHOD: SUM
+
+HRNetArchConfig:
+  _target_: mseg_semantic.model.seg_hrnet_config.HRNetArchConfig
+  FINAL_CONV_KERNEL: 1
+  
+  STAGE1:
+    _target_: mseg_semantic.model.seg_hrnet_config.HRNetStageConfig
+    NUM_MODULES: 1
+    NUM_BRANCHES: 1
+    BLOCK: BOTTLENECK
+    NUM_BLOCKS: [4]
+    NUM_CHANNELS: [64]
+    FUSE_METHOD: SUM
+  
+  STAGE2:
+    _target_: mseg_semantic.model.seg_hrnet_config.HRNetStageConfig
+    NUM_MODULES: 1
+    NUM_BRANCHES: 2
+    BLOCK: BASIC
+    NUM_BLOCKS: [4, 4]
+    NUM_CHANNELS: [48, 96]
+    FUSE_METHOD: SUM
+
+  STAGE3:
+    _target_: mseg_semantic.model.seg_hrnet_config.HRNetStageConfig
+    NUM_MODULES: 4
+    NUM_BRANCHES: 3
+    BLOCK: BASIC
+    NUM_BLOCKS: [4, 4, 4]
+    NUM_CHANNELS: [48, 96, 192]
+    FUSE_METHOD: SUM
+
+  STAGE4:
+    NUM_MODULES: 3
+    NUM_BRANCHES: 4
+    BLOCK: BASIC
+    NUM_BLOCKS: [4, 4, 4, 4]
+    NUM_CHANNELS: [48, 96, 192, 384]
+    FUSE_METHOD: SUM

--- a/mseg_semantic/model/seg_hrnet_config.py
+++ b/mseg_semantic/model/seg_hrnet_config.py
@@ -1,0 +1,60 @@
+
+
+from typing import List
+
+import hydra
+from hydra.utils import instantiate
+from omegaconf import OmegaConf
+
+from dataclasses import dataclass
+
+@dataclass
+class HRNetStageConfig:
+  """
+  `BLOCK' may be "BOTTLENECK" or "BASIC"
+
+  """
+  NUM_MODULES: int
+  NUM_BRANCHES: int
+  BLOCK: str
+  NUM_BLOCKS: List[int]
+  NUM_CHANNELS: List[int]
+  FUSE_METHOD: str = "SUM"
+
+
+@dataclass
+class HRNetArchConfig:
+  """ """
+  STAGE1: HRNetStageConfig
+  STAGE2: HRNetStageConfig
+  STAGE3: HRNetStageConfig
+  STAGE4: HRNetStageConfig
+  FINAL_CONV_KERNEL: int
+
+
+
+
+
+
+
+
+
+
+
+SceneOptimizer:
+  _target_: gtsfm.scene_optimizer.SceneOptimizer
+  save_gtsfm_data: True
+  save_two_view_correspondences_viz: False
+  save_3d_viz: True
+  pose_angular_error_thresh: 5 # degrees
+
+  feature_extractor:
+    _target_: gtsfm.feature_extractor.FeatureExtractor
+    detector_descriptor:
+      _target_: gtsfm.frontend.cacher.detector_descriptor_cacher.DetectorDescriptorCacher
+      detector_descriptor_obj:
+        _target_: gtsfm.frontend.detector_descriptor.superpoint.SuperPointDetectorDescriptor
+
+
+
+

--- a/mseg_semantic/model/seg_hrnet_config.py
+++ b/mseg_semantic/model/seg_hrnet_config.py
@@ -1,10 +1,7 @@
 
+"""Config definitions for the HRNet architecture."""
 
 from typing import List
-
-import hydra
-from hydra.utils import instantiate
-from omegaconf import OmegaConf
 
 from dataclasses import dataclass
 
@@ -30,31 +27,3 @@ class HRNetArchConfig:
   STAGE3: HRNetStageConfig
   STAGE4: HRNetStageConfig
   FINAL_CONV_KERNEL: int
-
-
-
-
-
-
-
-
-
-
-
-SceneOptimizer:
-  _target_: gtsfm.scene_optimizer.SceneOptimizer
-  save_gtsfm_data: True
-  save_two_view_correspondences_viz: False
-  save_3d_viz: True
-  pose_angular_error_thresh: 5 # degrees
-
-  feature_extractor:
-    _target_: gtsfm.feature_extractor.FeatureExtractor
-    detector_descriptor:
-      _target_: gtsfm.frontend.cacher.detector_descriptor_cacher.DetectorDescriptorCacher
-      detector_descriptor_obj:
-        _target_: gtsfm.frontend.detector_descriptor.superpoint.SuperPointDetectorDescriptor
-
-
-
-

--- a/mseg_semantic/scripts/collect_results.py
+++ b/mseg_semantic/scripts/collect_results.py
@@ -24,6 +24,7 @@ from scipy.stats.mstats import gmean
 
 class PrintOutputFormat(str, Enum):
     """ """
+
     LaTeX: str = "LaTeX"
     MARKDOWN: str = "MARKDOWN"
 

--- a/mseg_semantic/scripts/collect_results.py
+++ b/mseg_semantic/scripts/collect_results.py
@@ -217,8 +217,8 @@ def collect_oracle_results_at_res(resolution: str, scale: str, output_format: Pr
     results = []
     print(" " * 60, (" " * 5).join(o_datasets), " " * 10 + "mean")
     for m, name, d in zip(o_models, o_names, o_datasets):
-        folder = f"/srv/scratch/jlambert30/MSeg/pretrained-semantic-models/{m}/{m}/{d}"
-        miou = parse_folder(folder, resolution)
+        folder = f"{RESULTS_BASE_ROOT}/{m}/{m}/{d}"
+        miou = parse_folder(folder, resolution, scale)
         results.append(miou)
 
     dump_results_latex("Oracle", results)

--- a/mseg_semantic/scripts/collect_results.py
+++ b/mseg_semantic/scripts/collect_results.py
@@ -179,11 +179,11 @@ def collect_results_at_res(
         tmp_results = np.array(results)
         if mean_type == "harmonic":
             # results.append([len(tmp_results) / np.sum(1.0/np.array(tmp_results))])
-            results.append([harmonic_mean(tmp_results)])
+            results.append(harmonic_mean(tmp_results))
         elif mean_type == "arithmetic":
-            results.append([arithmetic_mean(tmp_results)])
+            results.append(arithmetic_mean(tmp_results))
         elif mean_type == "geometric":
-            results.append([geometric_mean(tmp_results)])
+            results.append(geometric_mean(tmp_results))
         else:
             print("Unknown mean type")
             exit()

--- a/mseg_semantic/scripts/collect_results.py
+++ b/mseg_semantic/scripts/collect_results.py
@@ -8,6 +8,9 @@ Results are expected in the following folder structure,
     where "M" is a model name, and "D" is a dataset name, e.g.
 
     {RESULTS_BASE_ROOT}/camvid-11-1m/camvid-11-1m/camvid-11/360/ss/results.txt 
+
+Note: models trained on a single training dataset are trained in the universal taxonomy, to avoid
+having to hand-specify 7 * 6 = 42 train to test taxonomy mappings.
 """
 
 import argparse
@@ -16,13 +19,12 @@ from enum import Enum
 from typing import List
 
 import numpy as np
-
 # import scipy.stats.hmean as hmean
 from scipy.stats.mstats import gmean
 
 
 class PrintOutputFormat(str, Enum):
-    """ """
+    """syntax for STDOUT table formatting."""
 
     LaTeX: str = "LaTeX"
     MARKDOWN: str = "MARKDOWN"
@@ -77,9 +79,9 @@ u_names = [
 ]
 # 'naive'
 
-# oracle taxonomy names
+# oracle taxonomy model filenames
 ORACLE_MODELS = ["voc2012-1m", "pascal-context-60-1m", "camvid-11-1m", "kitti-19-1m", "scannet-20-1m"]
-
+# formal names for models above
 ORACLE_NAMES = ["VOC Oracle", "PASCAL Context Oracle", "Camvid Oracle", "KITTI Oracle", "ScanNet Oracle"]
 
 # oracle-trained datasets

--- a/mseg_semantic/scripts/collect_results.py
+++ b/mseg_semantic/scripts/collect_results.py
@@ -12,7 +12,6 @@ Results are expected in the following folder structure,
 
 import argparse
 import os
-import pdb
 from enum import Enum
 from typing import List
 
@@ -195,7 +194,6 @@ def collect_results_at_res(
 
 def dump_results_latex(name: str, results: List[float]) -> None:
     """Dump a table to STDOUT in LaTeX syntax."""
-    import pdb; pdb.set_trace()
     results = [ "{:.1f}".format(r).rjust(5) for r in results]
     results = ["$ " + r + " $" for r in results]
     print(name.rjust(50), " & ", " & ".join(results) + "\\\\")

--- a/mseg_semantic/scripts/collect_results.py
+++ b/mseg_semantic/scripts/collect_results.py
@@ -220,8 +220,10 @@ def collect_oracle_results_at_res(resolution: str, scale: str, output_format: Pr
         miou = parse_folder(folder, resolution, scale)
         results.append(miou)
 
-    dump_results_latex("Oracle", results)
-    dump_results_markdown("Oracle", results)
+    if output_format == PrintOutputFormat.LaTeX:
+        dump_results_latex("Oracle", results)
+    elif output_format == PrintOutputFormat.MARKDOWN:
+        dump_results_markdown("Oracle", results)
 
 
 def collect_zero_shot_results(scale: str, output_format: PrintOutputFormat) -> None:

--- a/mseg_semantic/scripts/collect_results.py
+++ b/mseg_semantic/scripts/collect_results.py
@@ -22,6 +22,8 @@ import numpy as np
 # import scipy.stats.hmean as hmean
 from scipy.stats.mstats import gmean
 
+ROW_LEFT_JUSTIFY_OFFSET = 50
+
 
 class PrintOutputFormat(str, Enum):
     """syntax for STDOUT table formatting."""
@@ -46,7 +48,7 @@ training_datasets = [
 ]
 
 # universal taxonomy models
-u_models = [
+UNIVERSAL_TAX_MODEL_FNAMES = [
     "coco-panoptic-133-1m",
     "ade20k-150-1m",
     "mapillary-65-1m",
@@ -62,7 +64,7 @@ u_models = [
     "mseg-3m",
 ]
 
-u_names = [
+UNIVERSAL_TAX_MODEL_PRETTYPRINT_NAMES = [
     "COCO",
     "ADE20K",
     "Mapillary",
@@ -166,7 +168,7 @@ def collect_results_at_res(
 ) -> None:
     """Collect results from inference at a single resolution."""
     print(" " * 60, (" " * 5).join(datasets), " " * 10 + "mean")
-    for m, name in zip(u_models, u_names):
+    for m, name in zip(UNIVERSAL_TAX_MODEL_FNAMES, UNIVERSAL_TAX_MODEL_PRETTYPRINT_NAMES):
         results = []
         for d in datasets:
 
@@ -199,14 +201,14 @@ def dump_results_latex(name: str, results: List[float]) -> None:
     """Dump a table to STDOUT in LaTeX syntax."""
     results = ["{:.1f}".format(r).rjust(5) for r in results]
     results = ["$ " + r + " $" for r in results]
-    print(name.rjust(50), " & ", " & ".join(results) + "\\\\")
+    print(name.rjust(ROW_LEFT_JUSTIFY_OFFSET), " & ", " & ".join(results) + "\\\\")
 
 
 def dump_results_markdown(name: str, results: List[float]) -> None:
     """Dump a table to STDOUT in Markdown syntax."""
     results = ["{:.1f}".format(r).rjust(5) for r in results]
     results = ["| " + r + "" for r in results]
-    print(name.rjust(50), "  ", " ".join(results) + "|")
+    print(name.rjust(ROW_LEFT_JUSTIFY_OFFSET), "  ", " ".join(results) + "|")
 
 
 def collect_oracle_results_at_res(resolution: str, scale: str, output_format: PrintOutputFormat) -> None:

--- a/mseg_semantic/scripts/collect_results.py
+++ b/mseg_semantic/scripts/collect_results.py
@@ -33,9 +33,6 @@ RESULTS_BASE_ROOT = "/srv/scratch/jlambert30/MSeg/pretrained-semantic-models"
 # zero_shot_datasets
 zs_datasets = ["voc2012", "pascal-context-60", "camvid-11", "wilddash-19", "kitti-19", "scannet-20"]
 
-# oracle-trained datasets
-o_datasets = ["voc2012", "pascal-context-60", "camvid-11", "kitti-19", "scannet-20"]
-
 training_datasets = [
     "coco-panoptic-133_universal",
     "ade20k-150_universal",
@@ -81,9 +78,13 @@ u_names = [
 # 'naive'
 
 # oracle taxonomy names
-o_models = ["voc2012-1m", "pascal-context-60-1m", "camvid-11-1m", "kitti-19-1m", "scannet-20-1m"]
+ORACLE_MODELS = ["voc2012-1m", "pascal-context-60-1m", "camvid-11-1m", "kitti-19-1m", "scannet-20-1m"]
 
-o_names = ["VOC Oracle", "PASCAL Context Oracle", "Camvid Oracle", "KITTI Oracle", "ScanNet Oracle"]
+ORACLE_NAMES = ["VOC Oracle", "PASCAL Context Oracle", "Camvid Oracle", "KITTI Oracle", "ScanNet Oracle"]
+
+# oracle-trained datasets
+ORACLE_DATASETS = ["voc2012", "pascal-context-60", "camvid-11", "kitti-19", "scannet-20"]
+
 
 VERBOSE = False
 
@@ -194,7 +195,7 @@ def collect_results_at_res(
 
 def dump_results_latex(name: str, results: List[float]) -> None:
     """Dump a table to STDOUT in LaTeX syntax."""
-    results = [ "{:.1f}".format(r).rjust(5) for r in results]
+    results = ["{:.1f}".format(r).rjust(5) for r in results]
     results = ["$ " + r + " $" for r in results]
     print(name.rjust(50), " & ", " & ".join(results) + "\\\\")
 
@@ -209,13 +210,15 @@ def dump_results_markdown(name: str, results: List[float]) -> None:
 def collect_oracle_results_at_res(resolution: str, scale: str, output_format: PrintOutputFormat) -> None:
     """
     Args:
-        resolution:
-        scale:
-        output_format:
+        resolution: either "360", "720", "1080", or "max", which represents the best result
+            over all 3 aforementioned resolutions.
+        scale: string representing inference scale option,
+            either 'ss' or 'ms' (single-scale or multi-scale)
+        output_format: syntax for STDOUT result table formatting.
     """
     results = []
     print(" " * 60, (" " * 5).join(o_datasets), " " * 10 + "mean")
-    for m, name, d in zip(o_models, o_names, o_datasets):
+    for m, name, d in zip(ORACLE_MODELS, ORACLE_NAMES, ORACLE_DATASETS):
         folder = f"{RESULTS_BASE_ROOT}/{m}/{m}/{d}"
         miou = parse_folder(folder, resolution, scale)
         results.append(miou)
@@ -235,6 +238,10 @@ def collect_zero_shot_results(scale: str, output_format: PrintOutputFormat) -> N
 
 
 def collect_oracle_results(scale: str, output_format: PrintOutputFormat) -> None:
+    """Collect the results of oracle-trained models.
+
+    `Oracle' means trained on train split of test dataset, tested on test split of same test dataset.
+    """
     # 'ms' vs. 'ss'
     for resolution in ["360", "720", "1080", "max"]:  #  '480', '2160',
         print(f"At resolution {resolution}")
@@ -263,7 +270,11 @@ if __name__ == "__main__":
         "--scale", required=True, type=str, help="ss (single-scale) or ms (multi-scale)", choices=["ss", "ms"]
     )
     parser.add_argument(
-        "--output_format", required=True, type=str, help="latex or markdown", choices=["latex", "markdown"]
+        "--output_format",
+        required=True,
+        type=str,
+        help="syntax for STDOUT result table formatting (latex or markdown)",
+        choices=["latex", "markdown"],
     )
     args = parser.parse_args()
     print(args)

--- a/mseg_semantic/scripts/collect_results.py
+++ b/mseg_semantic/scripts/collect_results.py
@@ -202,13 +202,16 @@ def dump_results_latex(name: str, results: List[float]) -> None:
 
 def dump_results_markdown(name: str, results: List[float]) -> None:
     """Dump a table to STDOUT in Markdown syntax."""
+    import pdb; pdb.set_trace()
     results = ["{:.1f}".format(r).rjust(5) for r in results]
     results = ["| " + r + "" for r in results]
     print(name.rjust(50), "  ", " ".join(results) + "|")
 
 
 def collect_oracle_results_at_res(resolution: str, scale: str, output_format: PrintOutputFormat) -> None:
-    """
+    """For all test datasets (except WildDash), aggregate the results of the corresponding
+    oracle models at a specific resolution (from resolution-specific .txt files in subfolders).
+
     Args:
         resolution: either "360", "720", "1080", or "max", which represents the best result
             over all 3 aforementioned resolutions.
@@ -230,7 +233,9 @@ def collect_oracle_results_at_res(resolution: str, scale: str, output_format: Pr
 
 
 def collect_zero_shot_results(scale: str, output_format: PrintOutputFormat) -> None:
-    """ """
+    """Collect the results of zero-shot cross-dataset generalization experiments.
+
+    """
     # 'ms' vs. 'ss'
     for resolution in ["360", "720", "1080", "max"]:  #  '480', '2160',
         print(f"At resolution {resolution}")

--- a/mseg_semantic/scripts/collect_results.py
+++ b/mseg_semantic/scripts/collect_results.py
@@ -195,6 +195,7 @@ def collect_results_at_res(
 
 def dump_results_latex(name: str, results: List[float]) -> None:
     """Dump a table to STDOUT in LaTeX syntax."""
+    import pdb; pdb.set_trace()
     results = ["/".join(["{:.1f}".format(r).rjust(5) for r in x]) for x in results]
     results = ["$ " + r + " $" for r in results]
     print(name.rjust(50), " & ", " & ".join(results) + "\\\\")

--- a/mseg_semantic/scripts/collect_results.py
+++ b/mseg_semantic/scripts/collect_results.py
@@ -196,14 +196,14 @@ def collect_results_at_res(
 def dump_results_latex(name: str, results: List[float]) -> None:
     """Dump a table to STDOUT in LaTeX syntax."""
     import pdb; pdb.set_trace()
-    results = ["/".join(["{:.1f}".format(r).rjust(5) for r in x]) for x in results]
+    results = [ "{:.1f}".format(r).rjust(5) for r in results]
     results = ["$ " + r + " $" for r in results]
     print(name.rjust(50), " & ", " & ".join(results) + "\\\\")
 
 
 def dump_results_markdown(name: str, results: List[float]) -> None:
     """Dump a table to STDOUT in Markdown syntax."""
-    results = ["|".join(["{:.1f}".format(r).rjust(5) for r in x]) for x in results]
+    results = ["{:.1f}".format(r).rjust(5) for r in results]
     results = ["| " + r + "" for r in results]
     print(name.rjust(50), "  ", " ".join(results) + "|")
 

--- a/mseg_semantic/scripts/collect_results.py
+++ b/mseg_semantic/scripts/collect_results.py
@@ -202,7 +202,6 @@ def dump_results_latex(name: str, results: List[float]) -> None:
 
 def dump_results_markdown(name: str, results: List[float]) -> None:
     """Dump a table to STDOUT in Markdown syntax."""
-    import pdb; pdb.set_trace()
     results = ["{:.1f}".format(r).rjust(5) for r in results]
     results = ["| " + r + "" for r in results]
     print(name.rjust(50), "  ", " ".join(results) + "|")

--- a/mseg_semantic/scripts/eval_models.sh
+++ b/mseg_semantic/scripts/eval_models.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export outf=2020_07_18_test
+export outf=2021_11_25_test
 mkdir -p ${outf}
 
 

--- a/mseg_semantic/scripts/eval_models.sh
+++ b/mseg_semantic/scripts/eval_models.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export outf=2021_11_25_test
+export outf=2021_11_26_test
 mkdir -p ${outf}
 
 

--- a/mseg_semantic/scripts/eval_oracle_models.sh
+++ b/mseg_semantic/scripts/eval_oracle_models.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export outf=2020_07_18_test
+export outf=2021_11_25_test
 mkdir -p ${outf}
 
 

--- a/mseg_semantic/scripts/eval_oracle_models.sh
+++ b/mseg_semantic/scripts/eval_oracle_models.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export outf=2021_11_25_test
+export outf=2021_11_26_test
 mkdir -p ${outf}
 
 

--- a/mseg_semantic/scripts/eval_oracle_tax_model_overcap.sh
+++ b/mseg_semantic/scripts/eval_oracle_tax_model_overcap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --gpus 1
-#SBATCH --partition=short
+#SBATCH --partition=overcap
 #SBATCH --signal=USR1@300
 #SBATCH --requeue
 #SBATCH --account=overcap

--- a/mseg_semantic/scripts/eval_oracle_tax_model_overcap.sh
+++ b/mseg_semantic/scripts/eval_oracle_tax_model_overcap.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --gres gpu:1
+#SBATCH --gpus 1
 #SBATCH --partition=short
 #SBATCH --signal=USR1@300
 #SBATCH --requeue

--- a/mseg_semantic/scripts/eval_universal_tax_model_overcap_1gpu.sh
+++ b/mseg_semantic/scripts/eval_universal_tax_model_overcap_1gpu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --gpus 1
-#SBATCH --partition=short
+#SBATCH --partition=overcap
 #SBATCH --signal=USR1@300
 #SBATCH --requeue
 #SBATCH --account=overcap

--- a/mseg_semantic/scripts/eval_universal_tax_model_overcap_1gpu.sh
+++ b/mseg_semantic/scripts/eval_universal_tax_model_overcap_1gpu.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --gres gpu:1
+#SBATCH --gpus 1
 #SBATCH --partition=short
 #SBATCH --signal=USR1@300
 #SBATCH --requeue

--- a/mseg_semantic/scripts/eval_universal_tax_model_overcap_1gpu.sh
+++ b/mseg_semantic/scripts/eval_universal_tax_model_overcap_1gpu.sh
@@ -20,7 +20,7 @@ dataset_folder=$4
 config_fpath=../config/test/default_config_${base_size}_ss.yaml
 model_fpath=../../../pretrained-semantic-models/${model_name}/${model_name}.pth
 
-results_path=../../..pretrained-semantic-models/${model_name}/${model_name}/${dataset_folder}/${base_size}/ss/results.txt
+results_path=../../../pretrained-semantic-models/${model_name}/${model_name}/${dataset_folder}/${base_size}/ss/results.txt
 
 if [ -f ${results_path} ]
 then

--- a/mseg_semantic/scripts/eval_universal_tax_model_overcap_3gpu.sh
+++ b/mseg_semantic/scripts/eval_universal_tax_model_overcap_3gpu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --gpus 3
-#SBATCH --partition=short
+#SBATCH --partition=overcap
 #SBATCH --signal=USR1@300
 #SBATCH --requeue
 #SBATCH --account=overcap

--- a/mseg_semantic/scripts/eval_universal_tax_model_overcap_3gpu.sh
+++ b/mseg_semantic/scripts/eval_universal_tax_model_overcap_3gpu.sh
@@ -20,7 +20,7 @@ dataset_folder=$4
 config_fpath=../config/test/default_config_${base_size}_ss.yaml
 model_fpath=../../../pretrained-semantic-models/${model_name}/${model_name}.pth
 
-results_path=../../..pretrained-semantic-models/${model_name}/${model_name}/${dataset_folder}/${base_size}/ss/results.txt
+results_path=../../../pretrained-semantic-models/${model_name}/${model_name}/${dataset_folder}/${base_size}/ss/results.txt
 
 if [ -f ${results_path} ]
 then

--- a/mseg_semantic/scripts/eval_universal_tax_model_overcap_3gpu.sh
+++ b/mseg_semantic/scripts/eval_universal_tax_model_overcap_3gpu.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --gres gpu:3
+#SBATCH --gpus 3
 #SBATCH --partition=short
 #SBATCH --signal=USR1@300
 #SBATCH --requeue

--- a/mseg_semantic/tool/accuracy_calculator.py
+++ b/mseg_semantic/tool/accuracy_calculator.py
@@ -28,24 +28,12 @@ from mseg.utils.mask_utils import (
 )
 from mseg.utils.mask_utils_detectron2 import Visualizer
 from mseg.taxonomy.taxonomy_converter import TaxonomyConverter, DEFAULT_TRAIN_DATASETS
+from mseg_semantic.tool.relabeled_eval_utils import eval_rel_model_pred_on_unrel_data
 from mseg_semantic.utils.avg_meter import AverageMeter, SegmentationAverageMeter
 from mseg_semantic.utils.confusion_matrix_renderer import ConfusionMatrixRenderer
 from mseg_semantic.utils.img_path_utils import get_unique_stem_from_last_k_strs
 from mseg_semantic.utils.transform import ToUniversalLabel
-from mseg_semantic.tool.relabeled_eval_utils import eval_rel_model_pred_on_unrel_data
-
-
-def get_logger():
-    """ """
-    logger_name = "main-logger"
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(logging.INFO)
-    if not logger.handlers:
-        handler = logging.StreamHandler()
-        fmt = "[%(asctime)s %(levelname)s %(filename)s line %(lineno)d %(process)d] %(message)s"
-        handler.setFormatter(logging.Formatter(fmt))
-        logger.addHandler(handler)
-    return logger
+from mseg_semantic.utils.logger_utils import get_logger
 
 
 logger = get_logger()
@@ -234,7 +222,7 @@ class AccuracyCalculator:
                     self.id_to_class_name_map,
                 )
 
-    def print_results(self):
+    def print_results(self) -> None:
         """
         Dump per-class IoUs and mIoU to stdout.
         """

--- a/mseg_semantic/tool/batched_inference_task.py
+++ b/mseg_semantic/tool/batched_inference_task.py
@@ -34,8 +34,8 @@ def pad_to_crop_sz_batched(
         batch
         crop_h
         crop_w
-        mean
-        std
+        mean: RGB mean pixel values
+        std: RGB standard deviation of pixel values
 
     Returns:
         padded_batch
@@ -150,6 +150,7 @@ class BatchedInferenceTask(InferenceTask):
             batch: NCHW tensor
             native_h: image height @ native/raw image resolution, as found originally on disk
             native_w: image width @ native/raw image resolution, as found originally on disk
+            stride_rate:
         
         Returns:
             NCHW tensor where dimensions are (N, num_classes, H, W)

--- a/mseg_semantic/tool/inference_task.py
+++ b/mseg_semantic/tool/inference_task.py
@@ -17,9 +17,9 @@ import torch.nn.functional as F
 import torch.utils.data
 
 import mseg.utils.names_utils as names_utils
+import mseg.utils.resize_util as resize_util
 from mseg.utils.dir_utils import check_mkdir, create_leading_fpath_dirs
 from mseg.utils.mask_utils_detectron2 import Visualizer
-from mseg.utils.resize_util import resize_img_by_short_side
 from mseg.taxonomy.taxonomy_converter import TaxonomyConverter
 from mseg.taxonomy.naive_taxonomy_converter import NaiveTaxonomyConverter
 
@@ -30,6 +30,7 @@ from mseg_semantic.utils.cv2_video_utils import VideoWriter, VideoReader
 from mseg_semantic.utils import dataset, transform, config
 from mseg_semantic.utils.img_path_utils import dump_relpath_txt, get_unique_stem_from_last_k_strs
 from mseg_semantic.tool.mseg_dataloaders import create_test_loader
+from mseg_semantic.utils.logger_utils import get_logger
 
 
 """
@@ -71,19 +72,6 @@ There are 4 possible configurations for
 """
 
 _ROOT = Path(__file__).resolve().parent.parent.parent
-
-
-def get_logger():
-    """ """
-    logger_name = "main-logger"
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(logging.INFO)
-    if not logger.handlers:
-        handler = logging.StreamHandler()
-        fmt = "[%(asctime)s %(levelname)s %(filename)s line %(lineno)d %(process)d] %(message)s"
-        handler.setFormatter(logging.Formatter(fmt))
-        logger.addHandler(handler)
-    return logger
 
 
 logger = get_logger()
@@ -341,7 +329,7 @@ class InferenceTask:
 
         logger.info("<<<<<<<<<<< Inference task completed <<<<<<<<<<<<<<")
 
-    def render_single_img_pred(self, min_resolution: int = 1080):
+    def render_single_img_pred(self, min_resolution: int = 1080) -> None:
         """Since overlaid class text is difficult to read below 1080p, we upsample predictions."""
         in_fname_stem = Path(self.input_file).stem
         output_gray_fpath = f"{in_fname_stem}_gray.jpg"
@@ -353,8 +341,8 @@ class InferenceTask:
 
         # avoid blurry images by upsampling RGB before overlaying text
         if np.amin(rgb_img.shape[:2]) < min_resolution:
-            rgb_img = resize_img_by_short_side(rgb_img, min_resolution, "rgb")
-            pred_label_img = resize_img_by_short_side(pred_label_img, min_resolution, "label")
+            rgb_img = resize_util.resize_img_by_short_side(rgb_img, min_resolution, "rgb")
+            pred_label_img = resize_util.resize_img_by_short_side(pred_label_img, min_resolution, "label")
 
         metadata = None
         frame_visualizer = Visualizer(rgb_img, metadata)
@@ -433,8 +421,8 @@ class InferenceTask:
 
             # avoid blurry images by upsampling RGB before overlaying text
             if np.amin(rgb_img.shape[:2]) < min_resolution:
-                rgb_img = resize_img_by_short_side(rgb_img, min_resolution, "rgb")
-                pred_label_img = resize_img_by_short_side(pred_label_img, min_resolution, "label")
+                rgb_img = resize_util.resize_img_by_short_side(rgb_img, min_resolution, "rgb")
+                pred_label_img = resize_util.resize_img_by_short_side(pred_label_img, min_resolution, "label")
 
             metadata = None
             frame_visualizer = Visualizer(rgb_img, metadata)

--- a/mseg_semantic/tool/inference_task.py
+++ b/mseg_semantic/tool/inference_task.py
@@ -258,7 +258,7 @@ class InferenceTask:
         # (multi-scale vs. single-scale)
         self.scales_str = "ms" if len(args.scales) > 1 else "ss"
 
-    def load_model(self, args):
+    def load_model(self, args) -> nn.Module:
         """Load Pytorch pre-trained model from disk of type torch.nn.DataParallel.
 
         Note that `args.num_model_classes` will be size of logits output.
@@ -446,11 +446,11 @@ class InferenceTask:
         reader.complete()
         writer.complete()
 
-    def execute_on_dataloader(self, test_loader: torch.utils.data.dataloader.DataLoader):
+    def execute_on_dataloader(self, test_loader: torch.utils.data.dataloader.DataLoader) -> None:
         """Run a pretrained model over each batch in a dataloader.
 
         Args:
-             test_loader:
+             test_loader: dataloader.
         """
         if self.args.save_folder == "default":
             self.args.save_folder = f"{_ROOT}/temp_files/{self.args.model_name}_{self.args.dataset}_universal_{self.scales_str}/{self.args.base_size}"

--- a/mseg_semantic/tool/mseg_dataloaders.py
+++ b/mseg_semantic/tool/mseg_dataloaders.py
@@ -3,8 +3,8 @@
 import torch.utils.data
 from typing import List, Tuple
 
+import mseg_semantic.utils.normalization_utils as normalization_utils
 from mseg_semantic.utils import dataset, transform, config
-from mseg_semantic.utils.normalization_utils import get_imagenet_mean_std
 
 
 def create_test_loader(
@@ -24,7 +24,7 @@ def create_test_loader(
 
     if preprocess_imgs_in_loader:
         # resize and normalize images in advance
-        mean, std = get_imagenet_mean_std()
+        mean, std = normalization_utils.get_imagenet_mean_std()
         test_transform = transform.Compose(
             [transform.ResizeShort(args.base_size), transform.ToTensor(), transform.Normalize(mean=mean, std=std)]
         )

--- a/mseg_semantic/tool/test_oracle_tax.py
+++ b/mseg_semantic/tool/test_oracle_tax.py
@@ -6,10 +6,8 @@ import os
 from pathlib import Path
 from typing import List
 
-
 import cv2
 import mseg.utils.names_utils as names_utils
-import numpy as np
 import torch
 import torch.nn.functional as F
 from mseg.utils.dataset_config import infos
@@ -20,6 +18,7 @@ from mseg_semantic.utils.config import CfgNode
 from mseg_semantic.tool.accuracy_calculator import AccuracyCalculator
 from mseg_semantic.tool.inference_task import InferenceTask
 from mseg_semantic.tool.mseg_dataloaders import create_test_loader
+from mseg_semantic.utils.logger_utils import get_logger
 
 cv2.ocl.setUseOpenCL(False)
 
@@ -27,20 +26,6 @@ cv2.ocl.setUseOpenCL(False)
 Test an `oracle` model -- trained and tested on the same taxonomy/dataset.
 Thus, is designed for testing a single model's performance on a single-dataset.
 """
-
-
-def get_logger():
-    """ """
-    logger_name = "main-logger"
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(logging.INFO)
-    if not logger.handlers:
-        handler = logging.StreamHandler()
-        fmt = "[%(asctime)s %(levelname)s %(filename)s line %(lineno)d %(process)d] %(message)s"
-        handler.setFormatter(logging.Formatter(fmt))
-        logger.addHandler(handler)
-    return logger
-
 
 logger = get_logger()
 
@@ -75,7 +60,6 @@ def test_oracle_taxonomy_model(args, use_gpu: bool = True) -> None:
     Args:
         args:
         use_gpu: whether to use GPU for inference.
-
     """
     if "scannet" in args.dataset:
         args.img_name_unique = False

--- a/mseg_semantic/tool/test_universal_tax.py
+++ b/mseg_semantic/tool/test_universal_tax.py
@@ -19,6 +19,7 @@ from mseg_semantic.tool.inference_task import InferenceTask
 from mseg_semantic.tool.mseg_dataloaders import create_test_loader
 from mseg_semantic.utils import dataset, transform, config
 from mseg_semantic.utils.config import CfgNode
+from mseg_semantic.utils.logger_utils import get_logger
 
 
 """
@@ -35,22 +36,7 @@ and then evaluate only classes jointly present in the
 training dataset taxonomy and universal taxonomy.
 """
 
-
 cv2.ocl.setUseOpenCL(False)
-
-
-def get_logger():
-    """ """
-    logger_name = "main-logger"
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(logging.INFO)
-    if not logger.handlers:
-        handler = logging.StreamHandler()
-        fmt = "[%(asctime)s %(levelname)s %(filename)s line %(lineno)d %(process)d] %(message)s"
-        handler.setFormatter(logging.Formatter(fmt))
-        logger.addHandler(handler)
-    return logger
-
 
 logger = get_logger()
 

--- a/mseg_semantic/tool/test_universal_tax.py
+++ b/mseg_semantic/tool/test_universal_tax.py
@@ -3,18 +3,15 @@
 import argparse
 import cv2
 import logging
-import numpy as np
 import os
 from pathlib import Path
-import pdb
 import torch
 import torch.nn as nn
 from types import SimpleNamespace
 from typing import List, Optional, Tuple
-import time
 
 from mseg.utils.dataset_config import infos
-from mseg.utils.names_utils import load_class_names, get_universal_class_names
+import mseg.utils.names_utils as names_utils
 from mseg.taxonomy.taxonomy_converter import TaxonomyConverter, DEFAULT_TRAIN_DATASETS, TEST_DATASETS
 
 from mseg_semantic.tool.accuracy_calculator import AccuracyCalculator
@@ -112,7 +109,7 @@ def evaluate_universal_tax_model(args, use_gpu: bool = True) -> None:
     if args.split == "test":
         args.vis_freq = 1
 
-    args.num_model_classes = len(get_universal_class_names())
+    args.num_model_classes = len(names_utils.get_universal_class_names())
 
     if not args.has_prediction:
         itask = InferenceTask(
@@ -138,10 +135,10 @@ def evaluate_universal_tax_model(args, use_gpu: bool = True) -> None:
         excluded_ids = []
 
     if eval_taxonomy == "universal":
-        class_names = get_universal_class_names()
+        class_names = names_utils.get_universal_class_names()
         num_eval_classes = len(class_names)
     elif eval_taxonomy == "test_dataset":
-        class_names = load_class_names(args.dataset)
+        class_names = names_utils.load_class_names(args.dataset)
         num_eval_classes = len(class_names)
     elif eval_taxonomy == "naive":
         # get from NaiveTaxonomyConverter class attributes

--- a/mseg_semantic/tool/universal_demo.py
+++ b/mseg_semantic/tool/universal_demo.py
@@ -19,22 +19,9 @@ import mseg.utils.names_utils as names_utils
 from mseg_semantic.utils import config
 from mseg_semantic.utils.config import CfgNode
 from mseg_semantic.tool.inference_task import InferenceTask
-
+from mseg_semantic.utils.logger_utils import get_logger
 
 _ROOT = Path(__file__).resolve().parent.parent
-
-
-def get_logger():
-    """ """
-    logger_name = "main-logger"
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(logging.INFO)
-    if not logger.handlers:
-        handler = logging.StreamHandler()
-        fmt = "[%(asctime)s %(levelname)s %(filename)s line %(lineno)d %(process)d] %(message)s"
-        handler.setFormatter(logging.Formatter(fmt))
-        logger.addHandler(handler)
-    return logger
 
 
 logger = get_logger()

--- a/mseg_semantic/utils/confusion_matrix_renderer.py
+++ b/mseg_semantic/utils/confusion_matrix_renderer.py
@@ -9,7 +9,7 @@ import mseg_semantic.utils.confusion_matrix_utils as confusion_matrix_utils
 
 
 class ConfusionMatrixRenderer:
-    def __init__(self, save_folder, class_names: List[str], dataset_name: str) -> None:
+    def __init__(self, save_folder: str, class_names: List[str], dataset_name: str) -> None:
         """ """
         self.save_folder = save_folder
         self.class_names = np.array(class_names)

--- a/mseg_semantic/utils/transform.py
+++ b/mseg_semantic/utils/transform.py
@@ -36,7 +36,7 @@ class Compose(object):
 
 class ToTensor(object):
     # Converts numpy.ndarray (H x W x C) to a torch.FloatTensor of shape (C x H x W).
-    def __call__(self, image, label):
+    def __call__(self, image: np.ndarray, label: np.ndarray) -> Tuple[torch.Tensor, torch.Tensor]:
         if not isinstance(image, np.ndarray) or not isinstance(label, np.ndarray):
             raise (
                 RuntimeError("segtransform.ToTensor() only handle np.ndarray" "[eg: data readed by cv2.imread()].\n")
@@ -371,13 +371,13 @@ class RandomGaussianBlur(object):
 
 class RGB2BGR(object):
     # Converts image from RGB order to BGR order, for model initialized from Caffe
-    def __call__(self, image, label):
+    def __call__(self, image: np.ndarray, label: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
         return image, label
 
 
 class BGR2RGB(object):
     # Converts image from BGR order to RGB order, for model initialized from Pytorch
-    def __call__(self, image, label):
+    def __call__(self, image: np.ndarray, label: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         return image, label

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ opencv-python>=4.1.0.25
 pandas>=1.2.0
 Pillow
 PyYAML
-recordclass
 scipy>=1.2.1
 sklearn
 torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-apex
 imageio
 matplotlib
 numpy>=1.19.5
@@ -12,4 +11,3 @@ sklearn
 torch
 tqdm
 typing_extensions
-yacs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 imageio
+hydra-core
 matplotlib
 numpy>=1.19.5
 opencv-python>=4.1.0.25


### PR DESCRIPTION
- Delete all apex code from inference. The `apex` library is not actively maintained.
- Replace `yacs` HRNet config with a custom clean `hydra` schema for the config.